### PR TITLE
Changed PlatformBase.props' Platform Toolkit to Default

### DIFF
--- a/PropertySheets/PlatformBase.props
+++ b/PropertySheets/PlatformBase.props
@@ -3,8 +3,7 @@
 
   <PropertyGroup Label="Configuration">
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(DefaultPlatformToolset)'!='v142'">$(DefaultPlatformToolset)</PlatformToolset>
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'=='v142'">$(DefaultPlatformToolset)</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
 
   <ImportGroup Label="PropertySheets">

--- a/PropertySheets/PlatformBase.props
+++ b/PropertySheets/PlatformBase.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Configuration">
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(DefaultPlatformToolset)'!='v142'">$(DefaultPlatformToolset)_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(DefaultPlatformToolset)'!='v142'">$(DefaultPlatformToolset)</PlatformToolset>
     <PlatformToolset Condition="'$(DefaultPlatformToolset)'=='v142'">$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
 


### PR DESCRIPTION
This changes PlatformBase.props' Platform Toolkit to Default so that it can be used with newer versions of Visual Studio.