### PR TITLE
Revert "Fixed Azi's backend to WaveOut."

### DIFF
--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -104,9 +104,7 @@ EXPORT Boolean CALL InitiateAudio(AUDIO_INFO Audio_Info) {
 	memcpy(&AudioInfo, &Audio_Info, sizeof(AUDIO_INFO));
 
 	Configuration::LoadDefaults();
-	//snd = SoundDriverFactory::CreateSoundDriver(Configuration::getDriver());
-	//Fix backend to WaveOut
-	snd = SoundDriverFactory::CreateSoundDriver(SoundDriverType::SND_DRIVER_WAVEOUT);
+	snd = SoundDriverFactory::CreateSoundDriver(Configuration::getDriver());
 
 	if (snd == NULL)
 		return FALSE;


### PR DESCRIPTION
This reverts "Fixed Azi's backend to WaveOut."  because XAudio2 (and possibly DirectSound 8) now works in Windows 7 and below.

This reverts commit 014ff67e180c4ed9764886f1c02428576e317561.